### PR TITLE
fix: use asynch

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,4 +1,10 @@
-import { randomBytes, scryptSync, subtle } from "node:crypto";
+import {
+  type BinaryLike,
+  randomBytes,
+  scrypt,
+  subtle,
+  timingSafeEqual,
+} from "node:crypto";
 import { customId } from "@/common/id";
 
 export const createHash = async (key: string) => {
@@ -25,18 +31,38 @@ export const initializeAccessToken = ({
   };
 };
 
-export const createSecureHash = (secret: string) => {
+const scryptAsync = (
+  password: BinaryLike,
+  salt: BinaryLike,
+  keylen: number,
+): Promise<Buffer> => {
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, keylen, (err, derivedKey) => {
+      if (err) reject(err);
+      else resolve(derivedKey);
+    });
+  });
+};
+
+export const createSecureHash = async (secret: string) => {
   const data = new TextEncoder().encode(secret);
   const salt = randomBytes(32).toString("hex");
-  const derivedKey = scryptSync(data, salt, 64);
+  const derivedKey = await scryptAsync(data, salt, 64);
 
   return `${salt}:${derivedKey.toString("hex")}`;
 };
 
-export const verifySecureHash = (secret: string, hash: string) => {
-  const data = new TextEncoder().encode(secret);
-  const [salt, storedHash] = hash.split(":");
-  const derivedKey = scryptSync(data, String(salt), 64);
+export const verifySecureHash = async (secret: string, hash: string) => {
+  try {
+    const data = new TextEncoder().encode(secret);
+    const [salt, storedHash] = hash.split(":");
 
-  return storedHash === derivedKey.toString("hex");
+    const derivedKey = await scryptAsync(data, salt ?? "", 64);
+
+    const derivedKeyBuffer = Buffer.from(derivedKey);
+    const storedHashBuffer = Buffer.from(storedHash ?? "", "hex");
+    return timingSafeEqual(derivedKeyBuffer, storedHashBuffer);
+  } catch (_error) {
+    return false;
+  }
 };

--- a/src/server/api/middlewares/bearer-token.ts
+++ b/src/server/api/middlewares/bearer-token.ts
@@ -1,6 +1,7 @@
 import { verifySecureHash } from "@/lib/crypto";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
+import { nanoid } from "nanoid";
 import { ApiError } from "../error";
 
 export type accessTokenAuthMiddlewareOptions =
@@ -48,19 +49,12 @@ async function authenticateWithAccessToken(
 
   const accessToken = await findAccessToken(clientId, c);
 
-  if (!accessToken) {
-    throw new ApiError({
-      code: "UNAUTHORIZED",
-      message: "Bearer token is invalid",
-    });
-  }
-
   const isAccessTokenValid = await verifySecureHash(
     clientSecret,
-    accessToken.clientSecret,
+    accessToken?.clientSecret ?? nanoid(),
   );
 
-  if (!isAccessTokenValid) {
+  if (!isAccessTokenValid || !accessToken) {
     throw new ApiError({
       code: "UNAUTHORIZED",
       message: "Bearer token is invalid",


### PR DESCRIPTION
what this pr do
- replaces `scryptSync` with `scrypt` which is asynchronous and doesn't block the event loop since it's a expensive operation https://nodejs.org/en/learn/asynchronous-work/dont-block-the-event-loop#what-code-runs-on-the-worker-pool
- use node time safe equal to prevent timing attacks